### PR TITLE
Feat/transfer asaas account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 composer.phar
 /vendor/
+/.idea/
 
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file

--- a/readme.md
+++ b/readme.md
@@ -98,7 +98,7 @@ Asaas::charging()->usingToken($apiKey)->create($charging);
 |                    | [Tokenização](https://docs.asaas.com/reference/tokenizacao-de-cartao-de-credito) de cartão de crédito |     ✔️     |
 | **Transferências** |                                                                                                       |            |
 |                    |                                        Transferências externas                                        |     ✔️     |
-|                    |                                   Transferências entre contas Asaas                                   |     ❌     |
+|                    |                                   Transferências entre contas Asaas                                   |     ✔️     |
 |                    |                              Recuperar informações de uma transferência                               |     ✔️     |
 | **Webhook**        |                                                                                                       |            |
 |                    |                                Configuração de Webhook para cobranças                                 |     ✔️     |

--- a/src/Entity/Transfer/Transfer.php
+++ b/src/Entity/Transfer/Transfer.php
@@ -50,6 +50,15 @@ class Transfer extends Entity
     protected ?string $pixAddressKeyType = null;
 
     /**
+     * Transferência entre contas Asaas
+     * Só é possível fazer transferência entre contas Asaas para contas que possuam vínculo entre si,
+     * como conta raiz e subconta, ou duas subcontas de mesma conta raiz.
+     *
+     * @var $walletId string|null
+     */
+    protected ?string $walletId = null;
+
+    /**
      * Transferências via Pix permitem descrição
      *
      * @var $description string|null
@@ -62,6 +71,13 @@ class Transfer extends Entity
      * @var $scheduleDate string|null
     */
     protected ?string $scheduleDate = null;
+
+    /**
+     * Identificador da transferência no seu sistema
+     *
+     * @var $externalReference string|null
+     */
+    protected ?string $externalReference = null;
 
     public function getValue(): ?float
     {
@@ -137,6 +153,28 @@ class Transfer extends Entity
     public function setScheduleDate(?string $scheduleDate): self
     {
         $this->scheduleDate = $scheduleDate;
+        return $this;
+    }
+
+    public function getWalletId(): ?string
+    {
+        return $this->walletId;
+    }
+
+    public function setWalletId(?string $walletId): Transfer
+    {
+        $this->walletId = $walletId;
+        return $this;
+    }
+
+    public function getExternalReference(): ?string
+    {
+        return $this->externalReference;
+    }
+
+    public function setExternalReference(?string $externalReference): Transfer
+    {
+        $this->externalReference = $externalReference;
         return $this;
     }
 }


### PR DESCRIPTION
## O que foi feito

- Adicionado os campos `walletId` e `externalReference` na entidade `Transfer`
- Atualizado o README para refletir suporte à transferência entre contas Asaas

## Por que?

O Asaas suporta transferências entre contas com vínculo (raiz/subcontas) via `walletId`, o que antes não era suportado pelo SDK.